### PR TITLE
Clean catch blocks in ICRunner to be more concise (issue 63)

### DIFF
--- a/src/main/java/edu/uw/cse/testbayes/runner/IndividualClassRunner.java
+++ b/src/main/java/edu/uw/cse/testbayes/runner/IndividualClassRunner.java
@@ -48,10 +48,7 @@ public class IndividualClassRunner extends BlockJUnit4ClassRunner {
         this.firstFailFound = false;
         try {
             this.testObject = testClass.newInstance();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-            exit(1);
-        } catch (InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException e) {
             e.printStackTrace();
             exit(1);
         }
@@ -202,10 +199,7 @@ public class IndividualClassRunner extends BlockJUnit4ClassRunner {
         for (Method m : ms) {
             try {
                 m.invoke(testObject);
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-                exit(1);
-            } catch (InvocationTargetException e) {
+            } catch (IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();
                 exit(1);
             }

--- a/src/test/java/runner/utilTestClasses/TestRunner.java
+++ b/src/test/java/runner/utilTestClasses/TestRunner.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.*;
 
 @Ignore
-@RunWith(IndividualClassRunner.class)
+@RunWith(Suite.class)
 @Suite.SuiteClasses({
     Test1.class,
     Test2.class,


### PR DESCRIPTION
Closes #63 